### PR TITLE
Add trade metrics logging and metrics API endpoint

### DIFF
--- a/app/backend/routes/__init__.py
+++ b/app/backend/routes/__init__.py
@@ -8,6 +8,7 @@ from app.backend.routes.flow_runs import router as flow_runs_router
 from app.backend.routes.ollama import router as ollama_router
 from app.backend.routes.language_models import router as language_models_router
 from app.backend.routes.api_keys import router as api_keys_router
+from app.backend.services.metrics import router as metrics_router
 
 # Main API router
 api_router = APIRouter()
@@ -21,3 +22,4 @@ api_router.include_router(flow_runs_router, tags=["flow-runs"])
 api_router.include_router(ollama_router, tags=["ollama"])
 api_router.include_router(language_models_router, tags=["language-models"])
 api_router.include_router(api_keys_router, tags=["api-keys"])
+api_router.include_router(metrics_router, tags=["metrics"])

--- a/app/backend/services/metrics.py
+++ b/app/backend/services/metrics.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+from src.monitoring.metrics import MetricsRecorder
+
+router = APIRouter(prefix="/metrics", tags=["metrics"])
+metrics_recorder = MetricsRecorder()
+
+
+@router.get("/")
+def read_metrics():
+    """Return recorded metrics."""
+    return metrics_recorder.get_metrics()

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Monitoring package for metrics logging."""

--- a/src/monitoring/metrics.py
+++ b/src/monitoring/metrics.py
@@ -1,0 +1,106 @@
+import os
+import sqlite3
+import time
+from typing import Dict, List
+
+
+class MetricsRecorder:
+    """Record and retrieve trade metrics."""
+
+    def __init__(self, db_path: str = "data/metrics.db") -> None:
+        self.db_path = db_path
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        self._init_db()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self) -> None:
+        conn = self._get_conn()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trade_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                trade_id TEXT,
+                outcome REAL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS latency_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                trade_id TEXT,
+                latency_ms REAL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS return_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME,
+                cumulative_return REAL
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    # Recording methods
+    def record_trade_outcome(self, trade_id: str, outcome: float) -> None:
+        conn = self._get_conn()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO trade_metrics (trade_id, outcome) VALUES (?, ?)",
+            (trade_id, outcome),
+        )
+        conn.commit()
+        conn.close()
+
+    def record_execution_latency(self, trade_id: str, latency_ms: float) -> None:
+        conn = self._get_conn()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO latency_metrics (trade_id, latency_ms) VALUES (?, ?)",
+            (trade_id, latency_ms),
+        )
+        conn.commit()
+        conn.close()
+
+    def record_cumulative_return(self, cumulative_return: float, timestamp: float | None = None) -> None:
+        if timestamp is None:
+            timestamp = time.time()
+        conn = self._get_conn()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO return_metrics (timestamp, cumulative_return) VALUES (?, ?)",
+            (timestamp, cumulative_return),
+        )
+        conn.commit()
+        conn.close()
+
+    # Retrieval
+    def get_metrics(self) -> Dict[str, List[Dict]]:
+        conn = self._get_conn()
+        cur = conn.cursor()
+        cur.execute("SELECT trade_id, outcome, timestamp FROM trade_metrics")
+        trades = [
+            {"trade_id": t[0], "outcome": t[1], "timestamp": t[2]}
+            for t in cur.fetchall()
+        ]
+        cur.execute("SELECT trade_id, latency_ms, timestamp FROM latency_metrics")
+        latency = [
+            {"trade_id": t[0], "latency_ms": t[1], "timestamp": t[2]}
+            for t in cur.fetchall()
+        ]
+        cur.execute("SELECT timestamp, cumulative_return FROM return_metrics")
+        returns = [
+            {"timestamp": t[0], "cumulative_return": t[1]}
+            for t in cur.fetchall()
+        ]
+        conn.close()
+        return {"trades": trades, "latency": latency, "returns": returns}

--- a/tests/monitoring/test_metrics_logging.py
+++ b/tests/monitoring/test_metrics_logging.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.monitoring.metrics import MetricsRecorder
+from app.backend.services import metrics as metrics_service
+
+
+def test_metrics_logging_and_retrieval(tmp_path):
+    db_file = tmp_path / "metrics.db"
+    recorder = MetricsRecorder(db_path=str(db_file))
+    recorder.record_trade_outcome("trade1", 100.0)
+    recorder.record_execution_latency("trade1", 25.5)
+    recorder.record_cumulative_return(0.05, timestamp=1.0)
+
+    metrics = recorder.get_metrics()
+    assert metrics["trades"][0]["outcome"] == 100.0
+    assert metrics["latency"][0]["latency_ms"] == 25.5
+    assert metrics["returns"][0]["cumulative_return"] == 0.05
+
+
+def test_metrics_endpoint(tmp_path):
+    db_file = tmp_path / "metrics.db"
+    metrics_service.metrics_recorder = MetricsRecorder(db_path=str(db_file))
+    metrics_service.metrics_recorder.record_trade_outcome("trade2", 50.0)
+
+    app = FastAPI()
+    app.include_router(metrics_service.router)
+    client = TestClient(app)
+
+    response = client.get("/metrics/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["trades"][0]["trade_id"] == "trade2"
+    assert data["trades"][0]["outcome"] == 50.0


### PR DESCRIPTION
## Summary
- add `MetricsRecorder` for trade outcomes, latency, and returns stored in SQLite
- expose `/metrics` API endpoint for dashboard queries
- test metrics recording and endpoint retrieval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b906ccf3908323840be487330bf5cf