### PR TITLE
Add Alpaca live trading support

### DIFF
--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -132,6 +132,9 @@ class HedgeFundRequest(BaseHedgeFundRequest):
     end_date: Optional[str] = Field(default_factory=lambda: datetime.now().strftime("%Y-%m-%d"))
     start_date: Optional[str] = None
     initial_cash: float = 100000.0
+    live_trading: bool = False
+    alpaca_api_key: Optional[str] = None
+    alpaca_api_secret: Optional[str] = None
 
     def get_start_date(self) -> str:
         """Calculate start date if not provided"""

--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -172,6 +172,9 @@ def run_graph(
                 "model_name": model_name,
                 "model_provider": model_provider,
                 "request": request,  # Pass the request for agent-specific model access
+                "live_trading": getattr(request, "live_trading", False) if request else False,
+                "alpaca_api_key": getattr(request, "alpaca_api_key", None) if request else None,
+                "alpaca_api_secret": getattr(request, "alpaca_api_secret", None) if request else None,
             },
         },
     )

--- a/app/frontend/src/services/types.ts
+++ b/app/frontend/src/services/types.ts
@@ -49,6 +49,9 @@ export interface HedgeFundRequest extends BaseHedgeFundRequest {
   end_date?: string;
   start_date?: string;
   initial_cash?: number;
+  live_trading?: boolean;
+  alpaca_api_key?: string;
+  alpaca_api_secret?: string;
 }
 
 export interface BacktestRequest extends BaseHedgeFundRequest {

--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 from src.utils.progress import progress
 from src.utils.llm import call_llm
+from src.tools.alpaca_trading import submit_order
 
 
 class PortfolioDecision(BaseModel):
@@ -88,6 +89,30 @@ def portfolio_management_agent(state: AgentState, agent_id: str = "portfolio_man
     # Print the decision if the flag is set
     if state["metadata"]["show_reasoning"]:
         show_agent_reasoning({ticker: decision.model_dump() for ticker, decision in result.decisions.items()}, "Portfolio Manager")
+
+    # Optionally execute trades via Alpaca when live trading is enabled
+    if state["metadata"].get("live_trading"):
+        api_key = state["metadata"].get("alpaca_api_key")
+        api_secret = state["metadata"].get("alpaca_api_secret")
+        for ticker, decision in result.decisions.items():
+            action = decision.action.lower()
+            qty = int(decision.quantity)
+            if action == "hold" or qty <= 0:
+                continue
+
+            side = "buy" if action in ["buy", "cover"] else "sell"
+            try:
+                order = submit_order(
+                    symbol=ticker,
+                    qty=qty,
+                    side=side,
+                    api_key=api_key,
+                    api_secret=api_secret,
+                )
+                status_msg = f"Order {order.get('status', 'submitted')}"
+                progress.update_status(agent_id, ticker, status_msg)
+            except Exception as e:
+                progress.update_status(agent_id, ticker, f"Error: {e}")
 
     progress.update_status(agent_id, None, "Done")
 

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,9 @@ def run_hedge_fund(
     selected_analysts: list[str] = [],
     model_name: str = "gpt-4.1",
     model_provider: str = "OpenAI",
+    live_trading: bool = False,
+    alpaca_api_key: str | None = None,
+    alpaca_api_secret: str | None = None,
 ):
     # Start progress tracking
     progress.start()
@@ -81,6 +84,9 @@ def run_hedge_fund(
                     "show_reasoning": show_reasoning,
                     "model_name": model_name,
                     "model_provider": model_provider,
+                    "live_trading": live_trading,
+                    "alpaca_api_key": alpaca_api_key,
+                    "alpaca_api_secret": alpaca_api_secret,
                 },
             },
         )

--- a/src/tools/alpaca_trading.py
+++ b/src/tools/alpaca_trading.py
@@ -1,0 +1,79 @@
+import os
+from typing import Optional, List, Dict
+
+import requests
+
+ALPACA_BASE_URL = os.environ.get("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+
+
+def _auth_headers(api_key: str, api_secret: str) -> Dict[str, str]:
+    """Generate authentication headers for Alpaca API."""
+    return {
+        "APCA-API-KEY-ID": api_key,
+        "APCA-API-SECRET-KEY": api_secret,
+    }
+
+
+def get_account(api_key: str, api_secret: str, base_url: Optional[str] = None) -> Dict:
+    """Retrieve account information from Alpaca."""
+    url = f"{base_url or ALPACA_BASE_URL}/v2/account"
+    response = requests.get(url, headers=_auth_headers(api_key, api_secret))
+    if response.status_code >= 400:
+        raise Exception(f"Error fetching account: {response.status_code} - {response.text}")
+    return response.json()
+
+
+def submit_order(
+    symbol: str,
+    qty: int,
+    side: str,
+    order_type: str = "market",
+    time_in_force: str = "day",
+    api_key: Optional[str] = None,
+    api_secret: Optional[str] = None,
+    base_url: Optional[str] = None,
+    **kwargs,
+) -> Dict:
+    """Submit an order to Alpaca."""
+    if not api_key or not api_secret:
+        raise ValueError("Alpaca API key and secret are required")
+
+    url = f"{base_url or ALPACA_BASE_URL}/v2/orders"
+    payload = {
+        "symbol": symbol,
+        "qty": qty,
+        "side": side,
+        "type": order_type,
+        "time_in_force": time_in_force,
+        **kwargs,
+    }
+    response = requests.post(url, json=payload, headers=_auth_headers(api_key, api_secret))
+    if response.status_code >= 400:
+        raise Exception(f"Error submitting order: {response.status_code} - {response.text}")
+    return response.json()
+
+
+def get_order(order_id: str, api_key: str, api_secret: str, base_url: Optional[str] = None) -> Dict:
+    """Get information about a specific order."""
+    url = f"{base_url or ALPACA_BASE_URL}/v2/orders/{order_id}"
+    response = requests.get(url, headers=_auth_headers(api_key, api_secret))
+    if response.status_code >= 400:
+        raise Exception(f"Error fetching order: {response.status_code} - {response.text}")
+    return response.json()
+
+
+def list_orders(
+    status: str = "open",
+    api_key: Optional[str] = None,
+    api_secret: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> List[Dict]:
+    """List orders from Alpaca."""
+    if not api_key or not api_secret:
+        raise ValueError("Alpaca API key and secret are required")
+    url = f"{base_url or ALPACA_BASE_URL}/v2/orders"
+    params = {"status": status}
+    response = requests.get(url, params=params, headers=_auth_headers(api_key, api_secret))
+    if response.status_code >= 400:
+        raise Exception(f"Error listing orders: {response.status_code} - {response.text}")
+    return response.json()


### PR DESCRIPTION
## Summary
- add `alpaca_trading` helper with submit_order, get_account, and other Alpaca v2 endpoints
- allow portfolio manager to place live orders when `live_trading` is enabled and log confirmations
- thread live-trading flag and Alpaca credentials through run_hedge_fund, backend schemas and graph metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8fb3480348323b1eca058e5e38ede