### PR TITLE
Add streaming data client and broker integration

### DIFF
--- a/src/broker/__init__.py
+++ b/src/broker/__init__.py
@@ -1,0 +1,4 @@
+from .base import BrokerBase
+from .alpaca import AlpacaBroker
+
+__all__ = ["BrokerBase", "AlpacaBroker"]

--- a/src/broker/alpaca.py
+++ b/src/broker/alpaca.py
@@ -1,0 +1,23 @@
+"""Simple Alpaca broker adapter."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .base import BrokerBase
+
+
+class AlpacaBroker(BrokerBase):
+    """Adapter around an Alpaca client instance."""
+
+    def __init__(self, client):
+        self.client = client
+
+    def connect(self) -> None:  # pragma: no cover - simple delegation
+        self.client.get_account()
+
+    def place_order(self, symbol: str, qty: int, side: str, order_type: str = "market") -> Any:
+        return self.client.submit_order(symbol=symbol, qty=qty, side=side, type=order_type)
+
+    def get_positions(self) -> Dict[str, Any]:  # pragma: no cover - simple delegation
+        positions = self.client.list_positions()
+        return {p.symbol: p for p in positions}

--- a/src/broker/base.py
+++ b/src/broker/base.py
@@ -1,0 +1,21 @@
+"""Broker interface definitions."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class BrokerBase(ABC):
+    """Abstract broker interface."""
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Establish connection to broker API."""
+
+    @abstractmethod
+    def place_order(self, symbol: str, qty: int, side: str, order_type: str = "market") -> Any:
+        """Place an order and return broker-specific response."""
+
+    @abstractmethod
+    def get_positions(self) -> Dict[str, Any]:
+        """Return current positions."""

--- a/src/data/streaming.py
+++ b/src/data/streaming.py
@@ -1,0 +1,35 @@
+"""Utilities for streaming market data into application state."""
+from __future__ import annotations
+
+import json
+from typing import Iterable
+from types import SimpleNamespace
+
+from src.graph.state import AgentState
+
+try:  # pragma: no cover - handled in tests via mocking
+    import websockets as _websockets  # type: ignore
+except Exception:  # pragma: no cover
+    _websockets = SimpleNamespace()
+
+websockets = _websockets
+
+
+async def stream_prices(tickers: Iterable[str], state: AgentState, url: str = "ws://localhost"):
+    """Connect to a WebSocket feed and push price updates into ``state``.
+
+    The function subscribes to ``tickers`` and stores the latest price for
+    each ticker under ``state['data']['prices']``.
+    """
+    if not hasattr(websockets, "connect"):
+        raise ImportError("websockets package is required for streaming")
+
+    async with websockets.connect(url) as ws:  # type: ignore[attr-defined]
+        await ws.send(json.dumps({"type": "subscribe", "tickers": list(tickers)}))
+        async for message in ws:
+            data = json.loads(message)
+            ticker = data.get("ticker")
+            price = data.get("price")
+            if ticker is None or price is None:
+                continue
+            state.setdefault("data", {}).setdefault("prices", {})[ticker] = price

--- a/tests/broker/test_execution.py
+++ b/tests/broker/test_execution.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+from src.agents.portfolio_manager import (
+    PortfolioDecision,
+    PortfolioManagerOutput,
+    portfolio_management_agent,
+)
+
+
+def minimal_state(broker):
+    return {
+        "messages": [],
+        "data": {"portfolio": {}, "analyst_signals": {}, "tickers": ["AAPL"]},
+        "metadata": {"show_reasoning": False, "broker": broker},
+    }
+
+
+def test_portfolio_manager_executes_orders():
+    broker = MagicMock()
+    state = minimal_state(broker)
+    decision = PortfolioDecision(action="buy", quantity=5, confidence=1.0, reasoning="")
+    output = PortfolioManagerOutput(decisions={"AAPL": decision})
+
+    with patch("src.agents.portfolio_manager.progress.update_status"), \
+         patch("src.agents.portfolio_manager.generate_trading_decision", return_value=output):
+        portfolio_management_agent(state)
+
+    broker.place_order.assert_called_once_with("AAPL", 5, "buy")
+    assert state["data"]["executed_orders"]["AAPL"]["quantity"] == 5

--- a/tests/broker/test_streaming.py
+++ b/tests/broker/test_streaming.py
@@ -1,0 +1,40 @@
+import asyncio
+import json
+from unittest.mock import patch
+
+from src.data.streaming import stream_prices
+
+
+class DummyWebSocket:
+    def __init__(self, messages):
+        self.messages = messages
+        self.sent = []
+
+    async def send(self, message):
+        self.sent.append(message)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def __aiter__(self):
+        async def gen():
+            for m in self.messages:
+                yield m
+        return gen()
+
+def test_stream_prices_updates_state():
+    messages = [json.dumps({"ticker": "AAPL", "price": 150}), json.dumps({"ticker": "TSLA", "price": 200})]
+    state = {"messages": [], "data": {}, "metadata": {}}
+    ws = DummyWebSocket(messages)
+
+    async def run():
+        with patch("src.data.streaming.websockets.connect", return_value=ws):
+            await stream_prices(["AAPL", "TSLA"], state, url="ws://test")
+
+    asyncio.run(run())
+
+    assert state["data"]["prices"] == {"AAPL": 150, "TSLA": 200}
+    assert json.loads(ws.sent[0]) == {"type": "subscribe", "tickers": ["AAPL", "TSLA"]}


### PR DESCRIPTION
## Summary
- add websocket streaming client updating application state
- define broker interface with Alpaca implementation
- execute portfolio decisions via broker and test streaming/execution flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90673919483239b72f1d0bfa3e80f