### PR TITLE
chore: handle flow completion via sse events

### DIFF
--- a/app/frontend/src/hooks/use-flow-connection.ts
+++ b/app/frontend/src/hooks/use-flow-connection.ts
@@ -134,8 +134,7 @@ export function useFlowConnection(flowId: string | null) {
         abortController,
       });
 
-      // TODO: We should enhance the API to notify us when the connection completes
-      // For now, we'll rely on the complete event from the SSE stream
+      // Connection completion is handled via SSE complete events
       
     } catch (error) {
       console.error('Failed to start hedge fund run:', error);
@@ -170,8 +169,7 @@ export function useFlowConnection(flowId: string | null) {
         abortController,
       });
 
-      // TODO: We should enhance the API to notify us when the connection completes
-      // For now, we'll rely on the complete event from the SSE stream
+      // Connection completion is handled via SSE complete events
       
     } catch (error) {
       console.error('Failed to start backtest:', error);


### PR DESCRIPTION
## Summary
- document that SSE complete events handle flow completion and remove outdated TODOs
- clarify that both hedge fund runs and backtests rely on SSE completion notifications

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b93cdadd90832388a80cf604f8ae5b