### PR TITLE
Add websocket streaming client and broker interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ questionary = "^2.1.0"
 rich = "^13.9.4"
 langchain-google-genai = "^2.0.11"
 alpaca-trade-api = "^3.0.0"
+# Websocket streaming
+websockets = "^12.0"
 # Backend dependencies
 fastapi = {extras = ["standard"], version = "^0.104.0"}
 fastapi-cli = "^0.0.7"

--- a/src/broker/__init__.py
+++ b/src/broker/__init__.py
@@ -1,0 +1,71 @@
+"""Broker interfaces and implementations.
+
+This module defines a simple broker abstraction used by the trading
+agents.  It currently ships with an :class:`AlpacaBroker` implementation
+that proxies requests to the helper functions in
+``src.tools.alpaca_trading``.  The interface is intentionally small and
+focused on order submission which keeps the tests light weight while
+making the rest of the codebase agnostic to the underlying broker.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+from src.tools import alpaca_trading
+
+
+class Broker(ABC):
+    """Abstract base class for brokers."""
+
+    @abstractmethod
+    def submit_order(
+        self,
+        symbol: str,
+        qty: int,
+        side: str,
+        order_type: str = "market",
+        time_in_force: str = "day",
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Submit an order and return the broker response."""
+
+
+class AlpacaBroker(Broker):
+    """Broker implementation using the Alpaca trading API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        api_secret: str,
+        base_url: Optional[str] = None,
+    ) -> None:
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.base_url = base_url
+
+    def submit_order(
+        self,
+        symbol: str,
+        qty: int,
+        side: str,
+        order_type: str = "market",
+        time_in_force: str = "day",
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        return alpaca_trading.submit_order(
+            symbol=symbol,
+            qty=qty,
+            side=side,
+            order_type=order_type,
+            time_in_force=time_in_force,
+            api_key=self.api_key,
+            api_secret=self.api_secret,
+            base_url=self.base_url,
+            **kwargs,
+        )
+
+
+__all__ = ["Broker", "AlpacaBroker"]
+

--- a/src/tools/streaming.py
+++ b/src/tools/streaming.py
@@ -1,0 +1,53 @@
+"""Simple websocket streaming client.
+
+The client connects to a websocket endpoint and forwards any received
+JSON messages to a user provided handler.  The handler can mutate
+application state, execute trades or perform any other side effect.  The
+client is intentionally tiny but fully asynchronous which makes it easy
+to test using the ``websockets`` library.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Callable, Dict, Optional
+
+import websockets
+
+MessageHandler = Callable[[Dict[str, Any]], None]
+
+
+class WebSocketStreamClient:
+    """Connect to a websocket and stream messages to a handler."""
+
+    def __init__(
+        self,
+        url: str,
+        handler: MessageHandler,
+        max_messages: Optional[int] = None,
+    ) -> None:
+        self.url = url
+        self.handler = handler
+        self.max_messages = max_messages
+
+    async def listen(self) -> None:
+        """Listen for messages until ``max_messages`` is reached."""
+
+        count = 0
+        async with websockets.connect(self.url) as websocket:
+            async for message in websocket:
+                data = json.loads(message)
+                self.handler(data)
+                count += 1
+                if self.max_messages and count >= self.max_messages:
+                    break
+
+    def start(self) -> None:
+        """Synchronously start listening to the websocket."""
+
+        asyncio.run(self.listen())
+
+
+__all__ = ["WebSocketStreamClient"]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import sys
+import types
+
+
+# Stub optional LLM provider packages so importing modules that depend on
+# them does not require the actual heavy dependencies during tests.
+sys.modules.setdefault("langchain_anthropic", types.SimpleNamespace(ChatAnthropic=object))
+sys.modules.setdefault("langchain_deepseek", types.SimpleNamespace(ChatDeepSeek=object))
+sys.modules.setdefault(
+    "langchain_google_genai", types.SimpleNamespace(ChatGoogleGenerativeAI=object)
+)
+sys.modules.setdefault("langchain_groq", types.SimpleNamespace(ChatGroq=object))
+sys.modules.setdefault("langchain_xai", types.SimpleNamespace(ChatXAI=object))
+sys.modules.setdefault(
+    "langchain_openai", types.SimpleNamespace(ChatOpenAI=object, AzureChatOpenAI=object)
+)
+sys.modules.setdefault("langchain_gigachat", types.SimpleNamespace(GigaChat=object))
+sys.modules.setdefault("langchain_ollama", types.SimpleNamespace(ChatOllama=object))
+

--- a/tests/test_streaming_broker.py
+++ b/tests/test_streaming_broker.py
@@ -1,0 +1,120 @@
+import asyncio
+import json
+import sys
+import types
+
+import pytest
+import websockets
+
+# Stub out heavy optional LLM dependencies before importing portfolio manager
+sys.modules.setdefault("langchain_anthropic", types.SimpleNamespace(ChatAnthropic=object))
+sys.modules.setdefault("langchain_deepseek", types.SimpleNamespace(ChatDeepSeek=object))
+sys.modules.setdefault(
+    "langchain_google_genai", types.SimpleNamespace(ChatGoogleGenerativeAI=object)
+)
+sys.modules.setdefault("langchain_groq", types.SimpleNamespace(ChatGroq=object))
+sys.modules.setdefault("langchain_xai", types.SimpleNamespace(ChatXAI=object))
+sys.modules.setdefault(
+    "langchain_openai", types.SimpleNamespace(ChatOpenAI=object, AzureChatOpenAI=object)
+)
+sys.modules.setdefault("langchain_gigachat", types.SimpleNamespace(GigaChat=object))
+sys.modules.setdefault("langchain_ollama", types.SimpleNamespace(ChatOllama=object))
+
+from src.agents.portfolio_manager import (
+    PortfolioDecision,
+    PortfolioManagerOutput,
+    portfolio_management_agent,
+)
+from src.broker import Broker
+from src.tools.streaming import WebSocketStreamClient
+
+
+class DummyBroker(Broker):
+    def __init__(self) -> None:
+        self.orders: list[tuple[str, int, str]] = []
+
+    def submit_order(
+        self,
+        symbol: str,
+        qty: int,
+        side: str,
+        order_type: str = "market",
+        time_in_force: str = "day",
+        **kwargs,
+    ) -> dict:
+        self.orders.append((symbol, qty, side))
+        return {"symbol": symbol, "qty": qty, "side": side}
+
+
+def test_websocket_streaming_and_execution():
+    broker = DummyBroker()
+    state: dict[str, int] = {}
+
+    def handler(message: dict):
+        state.update(message)
+        if "order" in message:
+            broker.submit_order(**message["order"])
+
+    async def ws_handler(websocket):
+        await websocket.send(json.dumps({"price": 100}))
+        await websocket.send(
+            json.dumps({"order": {"symbol": "AAPL", "qty": 5, "side": "buy"}})
+        )
+        await asyncio.sleep(0.1)
+
+    async def runner():
+        server = await websockets.serve(ws_handler, "localhost", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        client = WebSocketStreamClient(f"ws://localhost:{port}", handler, max_messages=2)
+        await client.listen()
+
+        server.close()
+        await server.wait_closed()
+
+    asyncio.run(runner())
+
+    assert state["price"] == 100
+    assert broker.orders == [("AAPL", 5, "buy")]
+
+
+def test_portfolio_manager_executes_via_broker(monkeypatch):
+    broker = DummyBroker()
+
+    state = {
+        "messages": [],
+        "data": {
+            "portfolio": {},
+            "analyst_signals": {
+                "risk_management_agent": {
+                    "AAPL": {
+                        "remaining_position_limit": 1000,
+                        "current_price": 10,
+                    }
+                }
+            },
+            "tickers": ["AAPL"],
+        },
+        "metadata": {
+            "show_reasoning": False,
+            "live_trading": True,
+            "broker": broker,
+        },
+    }
+
+    decisions = PortfolioManagerOutput(
+        decisions={
+            "AAPL": PortfolioDecision(
+                action="buy", quantity=1, confidence=1.0, reasoning="test"
+            )
+        }
+    )
+
+    monkeypatch.setattr(
+        "src.agents.portfolio_manager.generate_trading_decision", lambda **_: decisions
+    )
+
+    portfolio_management_agent(state)
+
+    assert broker.orders == [("AAPL", 1, "buy")]
+


### PR DESCRIPTION
## Summary
- add lightweight websocket streaming client to update application state
- introduce Broker interface with Alpaca implementation
- execute portfolio trades via broker abstraction and test streaming & execution flows

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93fd069988323b9e2bf36d6b2b6f6