### PR TITLE
Use config for Alpaca credentials and drop old API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,25 @@ Create a `.env` file for your API keys:
 cp .env.example .env
 ```
 
-Open and edit the `.env` file to add your API keys:
+Open and edit the `.env` file to add your LLM API keys:
 ```bash
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 OPENAI_API_KEY=your-openai-api-key
-
-# Alpaca API credentials for market data
-APCA_API_KEY_ID=your-alpaca-key-id
-APCA_API_SECRET_KEY=your-alpaca-secret-key
 ```
 
-**Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work. 
+Then update `config.json` with your Alpaca credentials:
+```json
+{
+  "alpaca": {
+    "api_key_id": "your-alpaca-key-id",
+    "api_secret_key": "your-alpaca-secret-key"
+  }
+}
+```
 
-**Financial Data**: Set both `APCA_API_KEY_ID` and `APCA_API_SECRET_KEY` in your `.env` file to enable authenticated requests to Alpaca's market data APIs.
+**Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work.
+
+**Financial Data**: Alpaca API credentials in `config.json` enable authenticated requests to Alpaca's market data APIs.
 
 ## How to Run
 

--- a/app/README.md
+++ b/app/README.md
@@ -103,9 +103,16 @@ OPENAI_API_KEY=your-openai-api-key
 
 # For running LLMs hosted by groq (deepseek, llama3, etc.)
 GROQ_API_KEY=your-groq-api-key
+```
 
-# For getting financial data to power the hedge fund
-APCA_API_KEY_ID=your-financial-datasets-api-key
+Edit `config.json` to add your Alpaca API credentials:
+```json
+{
+  "alpaca": {
+    "api_key_id": "your-alpaca-key-id",
+    "api_secret_key": "your-alpaca-secret-key"
+  }
+}
 ```
 
 4. Install Poetry (if not already installed):

--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -43,9 +43,16 @@ OPENAI_API_KEY=your-openai-api-key
 
 # For running LLMs hosted by groq (deepseek, llama3, etc.)
 GROQ_API_KEY=your-groq-api-key
+```
 
-# For getting financial data to power the hedge fund
-APCA_API_KEY_ID=your-financial-datasets-api-key
+Edit `config.json` with your Alpaca API credentials:
+```json
+{
+  "alpaca": {
+    "api_key_id": "your-alpaca-key-id",
+    "api_secret_key": "your-alpaca-secret-key"
+  }
+}
 ```
 
 ## Running the Server

--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -224,7 +224,13 @@ class BacktestService:
         end_date_dt = datetime.strptime(self.end_date, "%Y-%m-%d")
         start_date_dt = end_date_dt - relativedelta(years=1)
         start_date_str = start_date_dt.strftime("%Y-%m-%d")
-        api_key = self.request.api_keys.get("APCA_API_KEY_ID")
+        api_key = None
+        if self.request.api_keys:
+            api_key = self.request.api_keys.get("APCA_API_KEY_ID")
+        if not api_key:
+            from src.config import get_alpaca_keys
+
+            api_key, _ = get_alpaca_keys()
 
         for ticker in self.tickers:
             get_prices(ticker, start_date_str, self.end_date, api_key=api_key)

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -16,10 +16,10 @@ interface ApiKey {
 const FINANCIAL_API_KEYS: ApiKey[] = [
   {
     key: 'APCA_API_KEY_ID',
-    label: 'Financial Datasets API',
+    label: 'Alpaca API',
     description: 'For getting financial data to power the hedge fund',
-    url: 'https://financialdatasets.ai/',
-    placeholder: 'your-financial-datasets-api-key'
+    url: 'https://alpaca.markets/',
+    placeholder: 'your-alpaca-api-key'
   }
 ];
 

--- a/app/run.bat
+++ b/app/run.bat
@@ -153,7 +153,7 @@ if not exist "..\.env" (
         echo %WARNING% Please edit ..\.env to add your API keys:
         echo %WARNING%   - OPENAI_API_KEY=your-openai-api-key
         echo %WARNING%   - GROQ_API_KEY=your-groq-api-key
-        echo %WARNING%   - APCA_API_KEY_ID=your-financial-datasets-api-key
+        echo %WARNING%   - Update config.json with your Alpaca API credentials
         echo.
     ) else (
         echo %ERROR% No .env or .env.example file found in the root directory.

--- a/app/run.sh
+++ b/app/run.sh
@@ -140,7 +140,7 @@ setup_environment() {
             print_warning "Please edit the .env file in the root directory to add your API keys:"
             print_warning "  - OPENAI_API_KEY=your-openai-api-key"
             print_warning "  - GROQ_API_KEY=your-groq-api-key"
-            print_warning "  - APCA_API_KEY_ID=your-financial-datasets-api-key"
+            print_warning "  - Update config.json with your Alpaca API credentials"
             echo ""
         else
             print_error "No .env or .env.example file found in the root directory."

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "alpaca": {
+    "api_key_id": "",
+    "api_secret_key": ""
+  }
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,18 +69,25 @@ Create a `.env` file for your API keys:
 cp .env.example .env
 ```
 
-Open and edit the `.env` file to add your API keys:
+Open and edit the `.env` file to add your LLM API keys:
 ```bash
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 OPENAI_API_KEY=your-openai-api-key
-
-# For getting financial data to power the hedge fund
-APCA_API_KEY_ID=your-financial-datasets-api-key
 ```
 
-**Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work. 
+Update `config.json` with your Alpaca API credentials for market data:
+```json
+{
+  "alpaca": {
+    "api_key_id": "your-alpaca-key-id",
+    "api_secret_key": "your-alpaca-secret-key"
+  }
+}
+```
 
-**Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, you will need to set the `APCA_API_KEY_ID` in the .env file.
+**Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work.
+
+**Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, supply your Alpaca credentials in `config.json`.
 
 ## How to Run
 

--- a/src/agents/research.py
+++ b/src/agents/research.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from langchain_core.messages import HumanMessage
 
 from src.graph.state import AgentState
-from src.utils.api_key import get_api_key_from_state
 from src.utils.llm import call_llm
 from src.utils.progress import progress
 
@@ -53,7 +52,7 @@ def research_analyst_agent(state: AgentState, agent_id: str = "research_analyst_
     """Generate a list of promising tickers using Alpaca screeners and news."""
     data = state.get("data", {})
     existing = set(data.get("tickers", []))
-    api_key = get_api_key_from_state(state, "ALPACA_API_KEY")
+    api_key = get_api_key_from_state(state, "APCA_API_KEY_ID")
 
     progress.update_status(agent_id, None, "Gathering market data")
     screener_symbols = _fetch_screener_symbols(api_key)

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+_config_cache: dict | None = None
+
+
+def _load_config() -> dict:
+    """Load configuration from config.json once and cache it."""
+    global _config_cache
+    if _config_cache is None:
+        config_path = Path(__file__).resolve().parent.parent / "config.json"
+        if config_path.exists():
+            with config_path.open() as f:
+                _config_cache = json.load(f)
+        else:
+            _config_cache = {}
+    return _config_cache
+
+
+def get_alpaca_keys() -> Tuple[Optional[str], Optional[str]]:
+    """Return Alpaca API key ID and secret from config file."""
+    config = _load_config()
+    alpaca_cfg = config.get("alpaca", {})
+    api_key = alpaca_cfg.get("api_key_id") or None
+    api_secret = alpaca_cfg.get("api_secret_key") or None
+    return api_key, api_secret

--- a/src/tools/alpaca_trading.py
+++ b/src/tools/alpaca_trading.py
@@ -3,18 +3,25 @@ from typing import Optional, List, Dict
 
 import requests
 
+from src.config import get_alpaca_keys
+
 ALPACA_BASE_URL = os.environ.get("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
 
 
-def _auth_headers(api_key: str, api_secret: str) -> Dict[str, str]:
+def _auth_headers(api_key: Optional[str] = None, api_secret: Optional[str] = None) -> Dict[str, str]:
     """Generate authentication headers for Alpaca API."""
+    cfg_key, cfg_secret = get_alpaca_keys()
+    api_key = api_key or cfg_key
+    api_secret = api_secret or cfg_secret
+    if not api_key or not api_secret:
+        raise ValueError("Alpaca API key and secret are required")
     return {
         "APCA-API-KEY-ID": api_key,
         "APCA-API-SECRET-KEY": api_secret,
     }
 
 
-def get_account(api_key: str, api_secret: str, base_url: Optional[str] = None) -> Dict:
+def get_account(api_key: Optional[str] = None, api_secret: Optional[str] = None, base_url: Optional[str] = None) -> Dict:
     """Retrieve account information from Alpaca."""
     url = f"{base_url or ALPACA_BASE_URL}/v2/account"
     response = requests.get(url, headers=_auth_headers(api_key, api_secret))
@@ -35,9 +42,6 @@ def submit_order(
     **kwargs,
 ) -> Dict:
     """Submit an order to Alpaca."""
-    if not api_key or not api_secret:
-        raise ValueError("Alpaca API key and secret are required")
-
     url = f"{base_url or ALPACA_BASE_URL}/v2/orders"
     payload = {
         "symbol": symbol,
@@ -53,7 +57,7 @@ def submit_order(
     return response.json()
 
 
-def get_order(order_id: str, api_key: str, api_secret: str, base_url: Optional[str] = None) -> Dict:
+def get_order(order_id: str, api_key: Optional[str] = None, api_secret: Optional[str] = None, base_url: Optional[str] = None) -> Dict:
     """Get information about a specific order."""
     url = f"{base_url or ALPACA_BASE_URL}/v2/orders/{order_id}"
     response = requests.get(url, headers=_auth_headers(api_key, api_secret))
@@ -69,8 +73,6 @@ def list_orders(
     base_url: Optional[str] = None,
 ) -> List[Dict]:
     """List orders from Alpaca."""
-    if not api_key or not api_secret:
-        raise ValueError("Alpaca API key and secret are required")
     url = f"{base_url or ALPACA_BASE_URL}/v2/orders"
     params = {"status": status}
     response = requests.get(url, params=params, headers=_auth_headers(api_key, api_secret))

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -12,6 +12,7 @@ from src.data.models import (
     LineItem,
     InsiderTrade,
 )
+from src.config import get_alpaca_keys
 
 # Global cache instance
 _cache = get_cache()
@@ -19,8 +20,9 @@ _cache = get_cache()
 
 def _alpaca_headers(api_key: str | None = None, secret_key: str | None = None) -> dict:
     """Build headers for Alpaca API requests."""
-    api_key = api_key or os.environ.get("APCA_API_KEY_ID")
-    secret_key = secret_key or os.environ.get("APCA_API_SECRET_KEY")
+    cfg_key, cfg_secret = get_alpaca_keys()
+    api_key = api_key or cfg_key or os.environ.get("APCA_API_KEY_ID")
+    secret_key = secret_key or cfg_secret or os.environ.get("APCA_API_SECRET_KEY")
     headers = {}
     if api_key:
         headers["APCA-API-KEY-ID"] = api_key

--- a/src/utils/api_key.py
+++ b/src/utils/api_key.py
@@ -1,11 +1,17 @@
 import os
+from typing import Optional
+
+from src.config import get_alpaca_keys
 
 
-def get_api_key_from_state(state: dict, api_key_name: str) -> str:
-    """Get an API key from the state object or environment."""
+def get_api_key_from_state(state: dict, api_key_name: str) -> Optional[str]:
+    """Get an API key from the state object, config file, or environment."""
     if state and state.get("metadata", {}).get("request"):
         request = state["metadata"]["request"]
         if hasattr(request, 'api_keys') and request.api_keys:
             if api_key_name in request.api_keys:
                 return request.api_keys.get(api_key_name)
+    if api_key_name in {"APCA_API_KEY_ID", "APCA_API_SECRET_KEY"}:
+        key_id, secret = get_alpaca_keys()
+        return key_id if api_key_name == "APCA_API_KEY_ID" else secret
     return os.environ.get(api_key_name)

--- a/tests/test_api_rate_limiting.py
+++ b/tests/test_api_rate_limiting.py
@@ -23,7 +23,7 @@ class TestRateLimiting:
         
         # Call the function
         headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://data.alpaca.markets/test"
         
         result = _make_api_request(url, headers)
         
@@ -62,7 +62,7 @@ class TestRateLimiting:
         
         # Call the function
         headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://data.alpaca.markets/test"
         
         result = _make_api_request(url, headers)
         
@@ -94,7 +94,7 @@ class TestRateLimiting:
         
         # Call the function with POST method
         headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://data.alpaca.markets/test"
         json_data = {"test": "data"}
         
         result = _make_api_request(url, headers, method="POST", json_data=json_data)
@@ -126,7 +126,7 @@ class TestRateLimiting:
         
         # Call the function
         headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://data.alpaca.markets/test"
         
         result = _make_api_request(url, headers)
         
@@ -153,7 +153,7 @@ class TestRateLimiting:
         
         # Call the function
         headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://data.alpaca.markets/test"
         
         result = _make_api_request(url, headers)
         
@@ -228,7 +228,7 @@ class TestRateLimiting:
         
         # Call the function with max_retries=2
         headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://data.alpaca.markets/test"
         
         result = _make_api_request(url, headers, max_retries=2)
         


### PR DESCRIPTION
## Summary
- load Alpaca API key and secret from a new `config.json`
- update API helpers, broker tools, and agents to read Alpaca credentials from config
- remove references to the previous financial data provider in code, docs, and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b96197cb248323b0cb14146a71eaef